### PR TITLE
Fix: Install fails with yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "url": "https://github.com/loadingio/loading.css"
   },
   "engines": {
-    "node": "=7.6.0",
-    "npm": "=3.9.5"
+    "node": ">=7.6.0",
+    "npm": ">=3.9.5"
   },
   "scripts": {},
   "devDependencies": {


### PR DESCRIPTION
Install fails with yarn: The engine "node" is incompatible with this module.
Yarn fails on purpose if the engine version doesn't match: yarnpkg/yarn#3430
This changes the version to only assert a minimum version instead of specifying an exact version.

closes #3